### PR TITLE
BUG/ENHANCEMENT - Fixed start day error and added additional filter...

### DIFF
--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -80,9 +80,14 @@ function pmprogl_pmpro_after_checkout($user_id)
 		
 	//create new gift code
 	$code = "G" . pmpro_getDiscountCode();
-	$starts = date("Y-m-d");
-	$expires = date("Y-m-d", strtotime("+1 year"));		
-	$sqlQuery = "INSERT INTO $wpdb->pmpro_discount_codes (code, starts, expires, uses) VALUES('" . esc_sql($code) . "', '" . $starts . "', '" . $expires . "', '1')";
+	$starts = date("Y-m-d", strtotime("-1 day"));
+	$expires = date("Y-m-d", strtotime("+1 year"));
+	$uses = 1;
+	
+	$gift_code_settings = array('code' => $code, 'starts' => $starts, 'expires' => $expires, 'uses' => $uses);
+	$gift_code_settings = apply_filters( 'pmprogl_gift_code_settings', $gift_code_settings);
+			
+	$sqlQuery = "INSERT INTO $wpdb->pmpro_discount_codes (code, starts, expires, uses) VALUES('" . esc_sql($gift_code_settings[code]) . "', '" . $gift_code_settings[starts] . "', '" . $gift_code_settings[expires] . "', '$gift_code_settings[uses]')";
 	
 	if($wpdb->query($sqlQuery) !== false)
 	{

--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -82,12 +82,16 @@ function pmprogl_pmpro_after_checkout($user_id)
 	$code = "G" . pmpro_getDiscountCode();
 	$starts = date("Y-m-d", strtotime("-1 day"));
 	$expires = date("Y-m-d", strtotime("+1 year"));
-	$uses = 1;
 	
-	$gift_code_settings = array('code' => $code, 'starts' => $starts, 'expires' => $expires, 'uses' => $uses);
-	$gift_code_settings = apply_filters( 'pmprogl_gift_code_settings', $gift_code_settings);
+	$gift_code_settings = apply_filters( 'pmprogl_gift_code_settings', array('code' => $code, 'starts' => $starts, 'expires' => $expires, 'uses' => 1 ) );
+
+	// Set variables and escape them right before the SQL query.
+	$gcode = esc_sql( $gift_code_settings['code'] );
+	$gstarts = esc_sql( $gift_code_settings['starts'] );
+	$gexpires = esc_sql( $gift_code_settings['expires'] );
+	$guses = esc_sql( $gift_code_settings['uses'] );
 			
-	$sqlQuery = "INSERT INTO $wpdb->pmpro_discount_codes (code, starts, expires, uses) VALUES('" . esc_sql($gift_code_settings[code]) . "', '" . $gift_code_settings[starts] . "', '" . $gift_code_settings[expires] . "', '$gift_code_settings[uses]')";
+	$sqlQuery = "INSERT INTO $wpdb->pmpro_discount_codes (code, starts, expires, uses) VALUES('" . esc_sql($gcode) . "', '" . $gstarts . "', '" . $gexpires . "', '$guses')";
 	
 	if($wpdb->query($sqlQuery) !== false)
 	{


### PR DESCRIPTION
for gift code settings.

Based on the timezone the start date would be incorrect preventing the gift code from being used immediately. This fix ensures the start date is set one day prior just in case. 

Additional filter `pmprogl_gift_code_settings` allows better control over gift code start date, expiration date, and uses.