### PR TITLE
Avoid notice when $post is undefined

### DIFF
--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -215,7 +215,7 @@ function pmprogl_the_content_account_page($content)
 {
 	global $post, $pmpro_pages, $current_user, $wpdb, $pmprogl_gift_levels;
 			
-	if(!is_admin() && $post->ID == $pmpro_pages['account'])
+	if(!is_admin() && isset( $post ) && $post->ID == $pmpro_pages['account'])
 	{
 		//get the user's last purchased gift code
 		$gift_codes = get_user_meta($current_user->ID, "pmprogl_gift_codes_purchased", true);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Avoid `PHP Notice:  Trying to get property 'ID' of non-object in /wp-content/plugins/pmpro-gift-levels/pmpro-gift-levels.php on line 218`

