### PR TITLE
Support users with no membership (new users)

### DIFF
--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -157,9 +157,7 @@ add_action("pmpro_after_checkout", "pmprogl_pmpro_after_checkout");
 function pmprogl_pmpro_checkout_before_change_membership_level() {
 	global $pmprogl_existing_member_flag, $pmprogl_gift_levels;
 
-	if ( pmpro_hasMembershipLevel()
-	&& ! empty( $_REQUEST['level'] )
-	&& ! empty( $pmprogl_gift_levels ) ) {
+	if ( ! empty( $_REQUEST['level'] ) && ! empty( $pmprogl_gift_levels ) ) {
 		$checkout_level_id = intval( $_REQUEST['level'] );
 		foreach ( $pmprogl_gift_levels as $level_id => $code ) {
 			if ( $level_id == $checkout_level_id ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With the OLD implementation, when buying a gift with a new user (no old membership), the result is a "buy one, get one free to gift". With this fix, it simply does what it should. Doesn't mess with the current user membership.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

