### PR TITLE
Get Membership Level from Order instead of Request

### DIFF
--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -158,7 +158,7 @@ function pmprogl_pmpro_checkout_before_change_membership_level( $user_id, $morde
 	global $pmprogl_existing_member_flag, $pmprogl_gift_levels;
 
 	if ( pmpro_hasMembershipLevel()
-	&& ! empty( $morder->membership_level->id )
+	&& ! empty( $morder->membership_id )
 	&& ! empty( $pmprogl_gift_levels ) ) {
 		$checkout_level_id = intval( $morder->membership_id );
 		foreach ( $pmprogl_gift_levels as $level_id => $code ) {

--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -77,7 +77,7 @@ function pmprogl_pmpro_after_checkout($user_id, $morder)
 	global $pmprogl_gift_levels, $wpdb, $pmprogl_existing_member_flag;
 	
 	//which level purchased
-	$level_id = intval($morder->membership_level->id);	
+	$level_id = intval($morder->membership_id);	
 		
 	//gift for this? if not, stop now
 	if(empty($pmprogl_gift_levels) || empty($pmprogl_gift_levels[$level_id]))

--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -160,7 +160,7 @@ function pmprogl_pmpro_checkout_before_change_membership_level( $user_id, $morde
 	if ( pmpro_hasMembershipLevel()
 	&& ! empty( $morder->membership_level->id )
 	&& ! empty( $pmprogl_gift_levels ) ) {
-		$checkout_level_id = intval( $morder->membership_level->id );
+		$checkout_level_id = intval( $morder->membership_id );
 		foreach ( $pmprogl_gift_levels as $level_id => $code ) {
 			if ( $level_id == $checkout_level_id ) {
 				add_filter('pmpro_cancel_previous_subscriptions', '__return_false');

--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -72,12 +72,12 @@ $pmprogl_require_gift_code = array(6);
 	When checking out for the purchase gift level, create a code.
 	
 */
-function pmprogl_pmpro_after_checkout($user_id)
+function pmprogl_pmpro_after_checkout($user_id, $morder)
 {	
 	global $pmprogl_gift_levels, $wpdb, $pmprogl_existing_member_flag;
 	
 	//which level purchased
-	$level_id = intval($_REQUEST['level']);	
+	$level_id = intval($morder->membership_level->id);	
 		
 	//gift for this? if not, stop now
 	if(empty($pmprogl_gift_levels) || empty($pmprogl_gift_levels[$level_id]))
@@ -149,18 +149,18 @@ function pmprogl_pmpro_after_checkout($user_id)
 		pmpro_set_current_user();
 	}
 }
-add_action("pmpro_after_checkout", "pmprogl_pmpro_after_checkout");
+add_action("pmpro_after_checkout", "pmprogl_pmpro_after_checkout", 10, 2);
 
 /*
  * Set existing member flags.
  */
-function pmprogl_pmpro_checkout_before_change_membership_level() {
+function pmprogl_pmpro_checkout_before_change_membership_level( $user_id, $morder ) {
 	global $pmprogl_existing_member_flag, $pmprogl_gift_levels;
 
 	if ( pmpro_hasMembershipLevel()
-	&& ! empty( $_REQUEST['level'] )
+	&& ! empty( $morder->membership_level->id )
 	&& ! empty( $pmprogl_gift_levels ) ) {
-		$checkout_level_id = intval( $_REQUEST['level'] );
+		$checkout_level_id = intval( $morder->membership_level->id );
 		foreach ( $pmprogl_gift_levels as $level_id => $code ) {
 			if ( $level_id == $checkout_level_id ) {
 				add_filter('pmpro_cancel_previous_subscriptions', '__return_false');
@@ -170,7 +170,7 @@ function pmprogl_pmpro_checkout_before_change_membership_level() {
 		}
 	}
 }
-add_action('pmpro_checkout_before_change_membership_level', 'pmprogl_pmpro_checkout_before_change_membership_level', 1);
+add_action('pmpro_checkout_before_change_membership_level', 'pmprogl_pmpro_checkout_before_change_membership_level', 1, 2);
 
 /*
 	Show last purchased gift code on the confirmation page.


### PR DESCRIPTION
Some third-party payment Gateways like Knit Pay don't redirect with Level Id in the URL, due to which addon was incompatible with such payment gateways. Getting memberships level from order instead of request is the safes option because order will be there in all the cases.

### All Submissions:

* [ ] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
