### PR TITLE
Fixed issue where buying gift level with Stripe could set expiration for prev level

### DIFF
--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -170,6 +170,7 @@ function pmprogl_pmpro_checkout_before_change_membership_level() {
 		}
 	}
 }
+add_action('pmpro_checkout_before_processing', 'pmprogl_pmpro_checkout_before_change_membership_level', 1);
 add_action('pmpro_checkout_before_change_membership_level', 'pmprogl_pmpro_checkout_before_change_membership_level', 1);
 
 /*


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes issue where a user's membership may be given an expiration date after purchasing a gift level using Stripe.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #32.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
