### PR TITLE
GUI setup

### DIFF
--- a/js/pmprogl-admin.js
+++ b/js/pmprogl-admin.js
@@ -1,0 +1,17 @@
+jQuery(document).ready(function () {
+	function pmprogl_update_field_visibility() {
+		if (jQuery('#pmprogl_gift_level').val() == '0') {
+			jQuery('#pmprogl_gift_expires_tr').hide();
+			jQuery('#pmprogl_period_tr').hide();
+		} else if (!jQuery('#pmprogl_gift_expires').is(':checked')) {
+			jQuery('#pmprogl_gift_expires_tr').show();
+			jQuery('#pmprogl_period_tr').hide();
+		} else {
+			jQuery('#pmprogl_gift_expires_tr').show();
+			jQuery('#pmprogl_period_tr').show();
+		}
+	}
+	jQuery('#pmprogl_gift_level, #pmprogl_gift_expires').change(function () {
+		pmprogl_update_field_visibility();
+	});
+});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add a GUI for setting up gift levels. If the array is already being created in PHP, the PHP array will overwrite the GUI settings.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #16.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
