### PR TITLE
Add warning if expiration or recurring is set for gift level

### DIFF
--- a/js/pmprogl-admin.js
+++ b/js/pmprogl-admin.js
@@ -1,12 +1,15 @@
 jQuery(document).ready(function () {
 	function pmprogl_update_field_visibility() {
 		if (jQuery('#pmprogl_gift_level').val() == '0') {
+			jQuery('.pmprogl_gift_level_warning').hide();
 			jQuery('#pmprogl_gift_expires_tr').hide();
 			jQuery('#pmprogl_period_tr').hide();
 		} else if (!jQuery('#pmprogl_gift_expires').is(':checked')) {
+			jQuery('.pmprogl_gift_level_warning').show();
 			jQuery('#pmprogl_gift_expires_tr').show();
 			jQuery('#pmprogl_period_tr').hide();
 		} else {
+			jQuery('.pmprogl_gift_level_warning').show();
 			jQuery('#pmprogl_gift_expires_tr').show();
 			jQuery('#pmprogl_period_tr').show();
 		}

--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -115,6 +115,7 @@ function pmprogl_membership_level_after_other_settings() {
 						<option value='0'></option>
 						<?php
 						$levels = pmpro_getAllLevels( true );
+						$current_level = $levels[ strval( $edit_level_id ) ];
 						unset( $levels[ strval( $edit_level_id ) ] );
 						foreach ( $levels as $level_id => $level ) {
 							echo "<option value='" . esc_attr( $level_id ) . "' " . selected( $gift_level, intval ( $level_id ), false ) . ">" . esc_html( $level->name ) . "</option>";
@@ -122,6 +123,17 @@ function pmprogl_membership_level_after_other_settings() {
 						?>
 					</select>
 					<label for="pmprogl_gift_level"><?php esc_html_e('Choose the level that a gift code is generated for when this level is purchased.', 'pmpro-gift-levels' );?></label>
+					<?php
+					// Show error if level has an expiration period or recurring payments set.
+					global $wpdb;
+					if ( ! empty( $current_level ) && ( ! empty( intval( $current_level->billing_amount ) ) || ! empty( intval( $current_level->expiration_number ) ) ) ) {
+						?>
+						<p class="description pmprogl_gift_level_warning" <?php if( empty( $gift_level ) ) {?>style="display: none;"<?php } ?>>
+							<strong class="pmpro_red"><?php esc_html_e( 'Memberships with Gift Levels should not have recurring payments or an expiration period set.', 'pmpro-gift-levels' ); ?></strong>
+						</p>
+						<?php
+					}
+					?>
 				</td>
 			</tr>
 			<tr id="pmprogl_gift_expires_tr" <?php if( empty( $gift_level ) ) {?>style="display: none;"<?php } ?>>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds warning into the Gift Levels GUI section if a gift level is set via the GUI and the level has an expiration date or recurring payments also set.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #38.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
