### PR TITLE
Added option to email gift recipient code

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -15,6 +15,11 @@ function pmprogl_membership_level_after_other_settings() {
 		$confirmation_message = '<p><strong>' . __( 'Share this link with your gift recipient' ) . ': <a href="!!pmprogl_gift_code_url!!">!!pmprogl_gift_code_url!!</a></p></strong>';
 	}
 
+	$allow_gift_emails = get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_allow_gift_emails', true );
+	if ( empty( $allow_gift_emails ) ) {
+		$allow_gift_emails = 'no';
+	}
+
 	$expiration_number = intval( get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_expiration_number', true ) );
 	$expiration_period = get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_expiration_period', true );
 	if ( empty( $expiration_period ) ) {
@@ -71,6 +76,13 @@ function pmprogl_membership_level_after_other_settings() {
 				</td>
 			</tr>
 			<tr id="pmprogl_gift_expires_tr" <?php if( empty( $gift_level ) ) {?>style="display: none;"<?php } ?>>
+ 				<th scope="row" valign="top"><label><?php esc_html_e('Allow Gift Emails', 'pmpro-gift-levels' );?>:</label></th>
+ 				<td>
+ 					<input id="pmprogl_allow_gift_emails" name="pmprogl_allow_gift_emails" type="checkbox" value="yes" <?php if( 'yes' === $allow_gift_emails ) { ?>checked="checked"<?php } ?> />
+ 					<label for="pmprogl_allow_gift_emails"><?php _e('Check to allow customers to enter an email address at checout to send the gift code to.', 'pmpro-gift-levels' );?></label>
+ 				</td>
+ 			</tr>
+			<tr id="pmprogl_gift_expires_tr" <?php if( empty( $gift_level ) ) {?>style="display: none;"<?php } ?>>
 				<th scope="row" valign="top"><label><?php esc_html_e('Gift Membership Expires', 'pmpro-gift-levels' );?>:</label></th>
 				<td>
 					<input id="pmprogl_gift_expires" name="pmprogl_gift_expires" type="checkbox" value="yes" <?php if ( $expiration_number ) { echo "checked='checked'"; } ?>/>
@@ -102,6 +114,7 @@ function pmprogl_save_membership_level( $save_id ) {
 	global $allowedposttags;
 	$gift_level           = intval( $_REQUEST['pmprogl_gift_level'] );
 	$confirmation_message = wp_kses( wp_unslash( $_REQUEST['pmprogl_confirmation_message'] ), $allowedposttags);
+	$allow_gift_emails = empty( $_REQUEST['pmprogl_allow_gift_emails'] ) ? 'no' : 'yes';
 	if ( empty( $gift_level ) || empty( $_REQUEST['pmprogl_gift_expires'] ) ) {
 		$expiration_number = 0;
 		$expiration_period = 'day';
@@ -112,6 +125,7 @@ function pmprogl_save_membership_level( $save_id ) {
 	
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_gift_level', $gift_level );
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_confirmation_message', $confirmation_message );
+	update_pmpro_membership_level_meta( $save_id, 'pmprogl_allow_gift_emails', $allow_gift_emails );
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_expiration_number', $expiration_number );
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_expiration_period', $expiration_period );
 }
@@ -149,6 +163,21 @@ function pmprogl_after_order_settings( $order ) {
 		<td>
 			<?php
 				echo esc_html( $gift_code );
+			?>
+		</td>
+	</tr>
+	<?php
+
+	$gift_recipient = get_pmpro_membership_order_meta( $order->id, 'pmprogl_recipient_email', true );
+	if ( empty( $gift_recipient ) ) {
+		return;
+	}
+	?>
+	<tr>
+		<th><?php esc_html_e( 'Gift Recipient Email', 'pmpro-gift-levels' ); ?></th>
+		<td>
+			<?php
+				echo esc_html( $gift_recipient );
 			?>
 		</td>
 	</tr>

--- a/includes/email.php
+++ b/includes/email.php
@@ -7,7 +7,7 @@
  * @param PMProEmail $pmpro_email being sent.
  * @return array
  */
-function pmprogl_email_data( $data, $pmpro_email ) {
+function pmprogl_checkout_email_data( $data, $pmpro_email ) {
 	global $wpdb, $pmprogl_gift_levels;
 
 	// Only create these variables if we have an invoice.
@@ -46,7 +46,7 @@ function pmprogl_email_data( $data, $pmpro_email ) {
 	}
 	return $data;
 }
-add_filter( 'pmpro_email_data', 'pmprogl_email_data', 10, 2 );
+add_filter( 'pmpro_email_data', 'pmprogl_checkout_email_data', 10, 2 );
 
 /**
  * If a PMPro Gift Level email template variable was not used, add the
@@ -83,3 +83,56 @@ function pmprogl_pmpro_email_body($body, $pmpro_email)
     return $body;
 }
 add_filter("pmpro_email_body", "pmprogl_pmpro_email_body", 10, 2);
+
+function pmprogl_send_gift_code_to_gift_recipient( $recipient_email, $gift_code ) {
+	global $pmprogl_gift_levels;
+
+	$email = new PMProEmail();
+	$email->email = $recipient_email;
+	$email->template = "pmprogl_gift_recipient";
+	$email->subject = esc_html__( "You have been gifted a membership to ", 'pmpro_gift_levels' ) . get_bloginfo('name') . "!";
+	$email->body = '<p>' . esc_html__( 'Use this link to setup your membership', 'pmpro-gift_levels' ) . ': <a href="!!pmprogl_gift_code_url!!">!!pmprogl_gift_code_url!!</a></p>';
+	$email->gift_code = $gift_code; // Save this for later.
+
+	add_filter( 'option_pmpro_email_header_disabled', '__return_true', 15 );
+	add_filter( 'default_option_pmpro_email_header_disabled', '__return_true', 15 );
+	$email->sendEmail();
+	remove_filter( 'option_pmpro_email_header_disabled', '__return_true', 15 );
+	remove_filter( 'default_option_pmpro_email_header_disabled', '__return_true', 15 );
+}
+
+/**
+ * Add "pmprogl_gift_recipient" as an editable email template.
+ *
+ * @param array $templates that can be edited.
+ */
+function pmprogl_template_callback( $templates ) {	
+	$templates['pmprogl_gift_recipient'] = array(
+		'subject' => esc_html__( "You have been gifted a membership to ", 'pmpro_gift_levels' ) . get_bloginfo('name') . "!",
+		'description' => 'Gift Recipient',
+		'body' => '<p>' . esc_html__( 'Use this link to setup your membership', 'pmpro-gift_levels' ) . ': <a href="!!pmprogl_gift_code_url!!">!!pmprogl_gift_code_url!!</a></p>',
+	);
+	
+	return $templates;
+}
+add_filter( 'pmproet_templates', 'pmprogl_template_callback');
+
+/**
+ * Add PMPro Gift Code email template variables to the gift recipeient email.
+ *
+ * @param array $data current email template variables.
+ * @param PMProEmail $pmpro_email being sent.
+ * @return array
+ */
+function pmprogl_gift_recipient_email_data( $data, $pmpro_email ) {
+	global $pmprogl_gift_levels, $pmpro_level;
+	if ( $pmpro_email->template === 'pmprogl_gift_recipient' ) {
+		if ( empty( $pmpro_email->gift_code ) ) {
+			$pmpro_email->gift_code = '';
+		}
+		$data['pmprogl_gift_code']     = $pmpro_email->gift_code;
+		$data['pmprogl_gift_code_url'] = pmpro_url("checkout", "?level=" . $pmprogl_gift_levels[ intval( $pmpro_level->id ) ]['level_id'] . "&discount_code=" . $pmpro_email->gift_code);
+	}
+	return $data;
+}
+add_filter( 'pmpro_email_data', 'pmprogl_gift_recipient_email_data', 10, 2 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added option to allow users to have the gift code emailed to the gift recipient. Email template is editable by PMPro Email Templates Add On.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #35.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
