### PR TITLE
Remove global pmprogl_existing_member_flag as no longer necessary

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -121,7 +121,7 @@ add_action("pmpro_before_send_to_twocheckout", "pmprogl_paypalexpress_session_va
  * @param MemberOrder|bool $morder created at checkout.
  */
 function pmprogl_pmpro_checkout_before_change_membership_level( $user_id = false, $morder = false ) {
-	global $pmprogl_existing_member_flag, $pmprogl_gift_levels;
+	global $pmprogl_gift_levels;
 
 	// Get the level that the user is checking out for.
 	if ( ! empty( $_REQUEST['level'] ) ) {
@@ -137,7 +137,6 @@ function pmprogl_pmpro_checkout_before_change_membership_level( $user_id = false
 	if ( ! empty( $pmprogl_gift_levels ) && array_key_exists( $level_id, $pmprogl_gift_levels ) ) {
 		add_filter('pmpro_cancel_previous_subscriptions', '__return_false');
 		add_filter('pmpro_deactivate_old_levels', '__return_false');
-		$pmprogl_existing_member_flag = true;
 	}
 }
 add_action('pmpro_checkout_before_processing', 'pmprogl_pmpro_checkout_before_change_membership_level', 1);
@@ -151,7 +150,7 @@ add_action('pmpro_checkout_before_change_membership_level', 'pmprogl_pmpro_check
  */
 function pmprogl_pmpro_after_checkout($user_id, $morder)
 {	
-	global $pmprogl_gift_levels, $wpdb, $pmprogl_existing_member_flag;
+	global $pmprogl_gift_levels, $wpdb;
 	
 	//which level purchased
 	$level_id = intval($morder->membership_id);	
@@ -251,24 +250,21 @@ function pmprogl_pmpro_after_checkout($user_id, $morder)
 		do_action( 'pmprogl_gift_code_purchased', $code_id, $user_id, $morder->id );
 	}
 
-	// $pmprogl_existing_member_flag is set below.
-	if(isset($pmprogl_existing_member_flag)) {
-		//remove last row added to members_users table
-		$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user_id . "' AND membership_id = '" . $level_id . "' ORDER BY id DESC LIMIT 1";
-		$wpdb->query($sqlQuery);
+	//remove last row added to members_users table
+	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user_id . "' AND membership_id = '" . $level_id . "' ORDER BY id DESC LIMIT 1";
+	$wpdb->query($sqlQuery);
 
-		// remove cached level
-		global $all_membership_levels;
-		unset( $all_membership_levels[$user_id] );
+	// remove cached level
+	global $all_membership_levels;
+	unset( $all_membership_levels[$user_id] );
 
-		// remove levels cache for user
-		$cache_key = 'user_' . $user_id . '_levels';
-		wp_cache_delete( $cache_key, 'pmpro' );
-		wp_cache_delete( $cache_key . '_all', 'pmpro' );
-		wp_cache_delete( $cache_key . '_active', 'pmpro' );
+	// remove levels cache for user
+	$cache_key = 'user_' . $user_id . '_levels';
+	wp_cache_delete( $cache_key, 'pmpro' );
+	wp_cache_delete( $cache_key . '_all', 'pmpro' );
+	wp_cache_delete( $cache_key . '_active', 'pmpro' );
 
-		// update user data and call action
-		pmpro_set_current_user();
-	}
+	// update user data and call action
+	pmpro_set_current_user();
 }
 add_action("pmpro_after_checkout", "pmprogl_pmpro_after_checkout", 10, 2);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?