### PR TITLE
Gift Levels email, wording, UI, and templates update

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -132,7 +132,7 @@ add_action( 'pmpro_membership_level_after_other_settings', 'pmprogl_membership_l
 function pmprogl_save_membership_level( $save_id ) {
 	global $allowedposttags;
 	$enabled              = empty( $_REQUEST['pmprogl_enabled_for_level'] ) ? 'no' : 'yes';
-	$gift_level			  = intval( empty( $_REQUEST['pmprogl_gift_level'] ? 0 : $_REQUEST['pmprogl_gift_level'] ) );
+	$gift_level			  = intval( empty( $_REQUEST['pmprogl_gift_level'] ) ? 0 : $_REQUEST['pmprogl_gift_level'] );
 	$confirmation_message = wp_kses( wp_unslash( $_REQUEST['pmprogl_confirmation_message'] ), $allowedposttags);
 	$allow_gift_emails = empty( $_REQUEST['pmprogl_allow_gift_emails'] ) ? 'no' : 'yes';
 	if ( empty( $gift_level ) || empty( $_REQUEST['pmprogl_gift_expires'] ) ) {

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -107,7 +107,7 @@ add_action( 'pmpro_membership_level_after_other_settings', 'pmprogl_membership_l
 function pmprogl_save_membership_level( $save_id ) {
 	global $allowedposttags;
 	$enabled              = empty( $_REQUEST['pmprogl_enabled_for_level'] ) ? 'no' : 'yes';
-	$gift_level			  = intval( empty( $_REQUEST['pmprogl_gift_level'] ) ? 0 : $_REQUEST['pmprogl_gift_level'] );
+	$gift_level			  = empty( $_REQUEST['pmprogl_gift_level'] ) ? 0 : intval( $_REQUEST['pmprogl_gift_level'] );
 	$allow_gift_emails = empty( $_REQUEST['pmprogl_allow_gift_emails'] ) ? 'no' : 'yes';
 	if ( empty( $gift_level ) || empty( $_REQUEST['pmprogl_gift_expires'] ) ) {
 		$expiration_number = 0;

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -14,11 +14,6 @@ function pmprogl_membership_level_after_other_settings() {
 
 	$gift_level           = intval( get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_gift_level', true ) );
 
-	$confirmation_message = get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_confirmation_message', true );
-	if ( empty( $confirmation_message ) ) {
-		$confirmation_message = '<p><strong>' . __( 'Share this link with your gift recipient' ) . ': <a href="!!pmprogl_gift_code_url!!">!!pmprogl_gift_code_url!!</a></p></strong>';
-	}
-
 	$allow_gift_emails = get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_allow_gift_emails', true );
 	if ( empty( $allow_gift_emails ) ) {
 		$allow_gift_emails = 'no';
@@ -72,32 +67,12 @@ function pmprogl_membership_level_after_other_settings() {
 					</select>
 				</td>
 			</tr>
-			<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php }  ?>>
-				<th scope="row" valign="top"><label for="pmprogl_confirmation_message"><?php esc_html_e('Gift Confirmation Message', 'pmpro-gift-levels' );?>:</label></th>
-				<td>
-					<div class="pmpro_confirmation">
-						<?php
-							if(version_compare($wp_version, '3.3') >= 0) {
-								wp_editor( $confirmation_message, 'pmprogl_confirmation_message', array( 'textarea_rows' => 5 ) );
-							} else {
-							?>
-							<textarea rows="10" name="pmprogl_confirmation_message" id="pmprogl_confirmation_message" class="large-text"><?php echo esc_textarea($confirmation_message);?></textarea>
-							<?php
-							}
-						?>
-						<p class="description">
-							<?php esc_html_e( 'This message will be shown in the checkout confirmation email.', 'pmpro-gift-levels' ); ?>
-							<?php echo wp_kses_post( 'Available variables are <code>!!pmprogl_gift_code!!</code> and <code>!!pmprogl_gift_code_url!!</code>', 'pmpro-gift-levels' ); ?>
-						</p>
-					</div>
-				</td>
-			</tr>
 			<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php } ?>>
 				<th scope="row" valign="top"><?php esc_html_e('Allow Gift Emails', 'pmpro-gift-levels' ); ?>:</th>
  				<td>
  					<input id="pmprogl_allow_gift_emails" name="pmprogl_allow_gift_emails" type="checkbox" value="yes" <?php if( 'yes' === $allow_gift_emails ) { ?>checked="checked"<?php } ?> />
 					<label for="pmprogl_allow_gift_emails"><?php esc_html_e( 'Check to allow customers to enter the recipient email address at checkout.', 'pmpro-gift-levels' );?></label>
-					<p class="description"><?php esc_html_e( 'If an email address is provided, the recipient will automatically receive an email containing the gift code. You can customize the "Gift Recipient" template on the Memberships > Settings > Email Templates page in the WordPress admin.', 'pmpro-gift-levels' ); ?></p>
+					<p class="description"><?php esc_html_e( 'If an email address is provided, the recipient will automatically receive an email containing a personalized message and a link to claim the gift code. You can customize the "Gift Recipient" template on the Memberships > Settings > Email Templates page in the WordPress admin.', 'pmpro-gift-levels' ); ?></p>
  				</td>
  			</tr>
 			<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php } ?>>
@@ -133,7 +108,6 @@ function pmprogl_save_membership_level( $save_id ) {
 	global $allowedposttags;
 	$enabled              = empty( $_REQUEST['pmprogl_enabled_for_level'] ) ? 'no' : 'yes';
 	$gift_level			  = intval( empty( $_REQUEST['pmprogl_gift_level'] ) ? 0 : $_REQUEST['pmprogl_gift_level'] );
-	$confirmation_message = wp_kses( wp_unslash( $_REQUEST['pmprogl_confirmation_message'] ), $allowedposttags);
 	$allow_gift_emails = empty( $_REQUEST['pmprogl_allow_gift_emails'] ) ? 'no' : 'yes';
 	if ( empty( $gift_level ) || empty( $_REQUEST['pmprogl_gift_expires'] ) ) {
 		$expiration_number = 0;
@@ -145,7 +119,6 @@ function pmprogl_save_membership_level( $save_id ) {
 
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_enabled_for_level', $enabled );
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_gift_level', $gift_level );
-	update_pmpro_membership_level_meta( $save_id, 'pmprogl_confirmation_message', $confirmation_message );
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_allow_gift_emails', $allow_gift_emails );
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_expiration_number', $expiration_number );
 	update_pmpro_membership_level_meta( $save_id, 'pmprogl_expiration_period', $expiration_period );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -132,7 +132,7 @@ add_action( 'pmpro_membership_level_after_other_settings', 'pmprogl_membership_l
 function pmprogl_save_membership_level( $save_id ) {
 	global $allowedposttags;
 	$enabled              = empty( $_REQUEST['pmprogl_enabled_for_level'] ) ? 'no' : 'yes';
-	$gift_level           = intval( $_REQUEST['pmprogl_gift_level'] );
+	$gift_level			  = intval( empty( $_REQUEST['pmprogl_gift_level'] ? 0 : $_REQUEST['pmprogl_gift_level'] ) );
 	$confirmation_message = wp_kses( wp_unslash( $_REQUEST['pmprogl_confirmation_message'] ), $allowedposttags);
 	$allow_gift_emails = empty( $_REQUEST['pmprogl_allow_gift_emails'] ) ? 'no' : 'yes';
 	if ( empty( $gift_level ) || empty( $_REQUEST['pmprogl_gift_expires'] ) ) {

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Show field to enter recipeient email at checkout.
+ * Show field to enter recipient email at checkout.
  *
  * Note: Can instead add this field with Register Helper by naming a field 'pmprogl_recipient_email`
  * and unchecking the allow gift emails box in the level settings.
@@ -268,14 +268,6 @@ function pmprogl_pmpro_after_checkout($user_id, $morder)
 			}
 		}
 
-		// Send email to gift recipient...
-		if ( ! empty( $recipient_email ) ) {
-			$code = $wpdb->get_var("SELECT code FROM $wpdb->pmpro_discount_codes WHERE id = '" . intval($code_id) . "' LIMIT 1");
-			if ( ! empty( $code ) ) {
-				pmprogl_send_gift_code_to_gift_recipient( $recipient_email, $gift_message, $code );
-			}
-		}
-
 		do_action( 'pmprogl_gift_code_purchased', $code_id, $user_id, $morder->id );
 	}
 
@@ -293,8 +285,89 @@ function pmprogl_pmpro_after_checkout($user_id, $morder)
 	wp_cache_delete( $cache_key . '_all', 'pmpro' );
 	wp_cache_delete( $cache_key . '_active', 'pmpro' );
 
-  // update user data and call action
+	// Update user data and call action.
 	pmpro_set_current_user();
+
+	// Don't send the default checkout emails to user or admin.
+	add_filter( 'pmpro_send_checkout_emails', '__return_false', 15 );
+
+	// Send the checkout emails to gift purchasers, admin, and gift recipient (optional).
+	global $current_user;
+
+	// Get the gift code from the database.
+	$code = $wpdb->get_var("SELECT code FROM $wpdb->pmpro_discount_codes WHERE id = '" . intval( $code_id ) . "' LIMIT 1");
+
+	// Set some empty variables if not set previously.
+	if ( ! isset( $recipient_email ) ) {
+		$recipient_email = '';
+	}
+	if ( ! isset( $gift_message ) ) {
+		$gift_message = '';
+	}
+
+	// Build the email template variable replacement data.
+	$data = array(
+		// Gift Membership data.
+		'pmprogl_gift_recipient_email' => $recipient_email,
+		'pmprogl_giver_display_name' => $current_user->display_name,
+		'pmprogl_gift_message' => wp_unslash( $gift_message ),
+		'pmprogl_gift_code' => $code,
+		'pmprogl_gift_code_url' => pmpro_url( 'checkout', '?level=' . intval( $gift['level_id'] ) . "&discount_code=" . $code ),
+
+		// Order data.
+		'invoice_id' => $morder->code,
+		'invoice_total' => pmpro_formatPrice($morder->total),
+		'invoice_date' => date_i18n(get_option('date_format'), $morder->getTimestamp()),
+		'billing_name' => $morder->billing->name,
+		'billing_street' => $morder->billing->street,
+		'billing_city' => $morder->billing->city,
+		'billing_state' => $morder->billing->state,
+		'billing_zip' => $morder->billing->zip,
+		'billing_country' => $morder->billing->country,
+		'billing_phone' => $morder->billing->phone,
+		'cardtype' => $morder->cardtype,
+		'accountnumber' => hideCardNumber($morder->accountnumber),
+		'expirationmonth' => $morder->expirationmonth,
+		'expirationyear' => $morder->expirationyear,
+		'billing_address' => pmpro_formatAddress($morder->billing->name,
+												 $morder->billing->street,
+												 "", //address 2
+												 $morder->billing->city,
+												 $morder->billing->state,
+												 $morder->billing->zip,
+												 $morder->billing->country,
+												 $morder->billing->phone),
+		'invoice_url' => pmpro_login_url( pmpro_url( 'invoice', '?invoice=' . $morder->code ) ),
+	);
+
+	// Send email to the gift purchaser.
+	$email_purchaser = new PMProEmail();
+	$email_purchaser->template = 'pmprogl_gift_purchased';
+	$email_purchaser->email = $current_user->email;
+	$email_purchaser->data = $data;
+	$email_purchaser->sendEmail();
+
+	// Send email to the site admin.
+	$email_admin = new PMProEmail();
+	$email_admin->template = 'pmprogl_gift_purchased_admin';
+	$email_admin->email = get_bloginfo( 'admin_email' );
+	$email_admin->data = $data;
+	$email_admin->sendEmail();
+
+	// Send email to the gift recipient (optional).
+	if ( ! empty( $recipient_email ) ) {
+		// Replace any default email data that is user-specific.
+		$new_data = array(
+			'name' => $recipient_email,
+			'display_name' => $recipient_email,
+			'user_email' => $recipient_email,
+		);
+		$email_recipient = new PMProEmail();
+		$email_recipient->template = 'pmprogl_gift_recipient';
+		$email_recipient->email = $recipient_email;
+		$email_recipient->data = array_merge( $data, $new_data );
+		$email_recipient->sendEmail();
+	}
 
 	// Send user to invoice after checkout instead of confirmation page since we took their level away.
 	add_action( 'pmpro_confirmation_url', 'pmprogl_overwrite_confirmation_url', 10, 2 );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -22,20 +22,22 @@ function pmprogl_checkout_boxes() {
 	<div id="pmprogl_checkout_box" class="pmpro_checkout">
 		<hr />
 		<h3>
-			<span class="pmpro_checkout-h3-name"><?php esc_html_e( 'Gift Code' );?></span>
+			<span class="pmpro_checkout-h3-name"><?php esc_html_e( 'Gift Code', 'pmpro-gift-levels' );?></span>
 		</h3>
-		<div class="pmpro_checkout-field">
-			<label for="pmprogl_send_recipient_email"><?php esc_html_e( 'Automatically email gift code to recipient after checkout' );?></label>
-			<input type="checkbox" id="pmprogl_send_recipient_email" name="pmprogl_send_recipient_email" value="1" <?php echo $send_recipient_email_checked; ?> />
-		</div>
-		<div class="pmpro_checkout-field pmprogl_checkout_field_div" <?php echo $gift_field_style_attr ?>>
-			<label for="pmprogl_recipient_email"><?php esc_html_e( 'Recipient Email' );?></label>
-			<input type="text" name="pmprogl_recipient_email" value="<?php echo esc_attr( $current_recipient_email ) ?>" />
-		</div>
-		<div class="pmpro_checkout-field pmprogl_checkout_field_div" <?php echo $gift_field_style_attr ?>>
-			<label for="pmprogl_gift_message"><?php esc_html_e( 'Gift Message' );?></label>
-			<textarea name="pmprogl_gift_message"><?php echo esc_textarea( $current_gift_message ); ?> </textarea>
-		</div>
+		<div class="pmpro_checkout-fields">
+			<div class="pmpro_checkout-field pmpro_checkout-field-checkbox">
+				<input type="checkbox" id="pmprogl_send_recipient_email" name="pmprogl_send_recipient_email" value="1" <?php echo $send_recipient_email_checked; ?> />
+				<label for="pmprogl_send_recipient_email"><?php esc_html_e( 'Automatically deliver the gift code by email after checkout.', 'pmpro-gift-levels' );?></label>
+			</div>
+			<div class="pmpro_checkout-field pmpro_checkout-field-text pmprogl_checkout_field_div" <?php echo $gift_field_style_attr ?>>
+				<label for="pmprogl_recipient_email"><?php esc_html_e( 'Recipient Email Address', 'pmpro-gift-levels' );?></label>
+				<input type="text" name="pmprogl_recipient_email" value="<?php echo esc_attr( $current_recipient_email ) ?>" />
+			</div>
+			<div class="pmpro_checkout-field pmpro_checkout-field-textarea pmprogl_checkout_field_div" <?php echo $gift_field_style_attr ?>>
+				<label for="pmprogl_gift_message"><?php esc_html_e( 'Add a Personalized Message (optional)', 'pmpro-gift-levels' );?></label>
+				<textarea name="pmprogl_gift_message"><?php echo esc_textarea( wp_unslash( $current_gift_message ) ); ?></textarea>
+			</div>
+		</div> <!-- end pmpro_checkout-fields -->
 	</div>
 	<?php
 }

--- a/includes/email.php
+++ b/includes/email.php
@@ -1,121 +1,27 @@
 <?php
-
 /**
- * Add PMPro Gift Code email template variables to checkout email.
- *
- * @param array $data current email template variables.
- * @param PMProEmail $pmpro_email being sent.
- * @return array
- */
-function pmprogl_checkout_email_data( $data, $pmpro_email ) {
-	global $wpdb, $pmprogl_gift_levels;
-
-	// Only create these variables if we have an invoice.
-	if ( strpos($pmpro_email->template, "checkout") !== false && strpos($pmpro_email->template, "admin") == false ) {
-		// Default to empty.
-		$data['pmprogl_gift_code']                 = '';
-		$data['pmprogl_gift_code_url']             = '';
-		$data['pmprogl_confirmation_message']      = '';
-		$data['pmprogl_hide_confirmation_message'] = ''; // Can be used to just hide the default pmprogl email message.
-		if ( version_compare( '2.5', PMPRO_VERSION, '<=' ) ) {
-			// Order meta was only implemented in PMPro v2.5.
-			// Get the order that was created for this checkout.
-			$morder = new MemberOrder();
-			$morder->getLastMemberOrder();
-
-			// Get the gift code ID purchased in the order.
-			$gift_code_id = get_pmpro_membership_order_meta( $morder->id, 'pmprogl_code_id', true );
-			if ( ! empty( $gift_code_id ) ) {
-				// Get the gift code purchased in the order.
-				$gift_code = $wpdb->get_var("SELECT code FROM $wpdb->pmpro_discount_codes WHERE id = '" . intval( $gift_code_id ) . "' LIMIT 1");
-				if ( ! empty( $gift_code ) ) {
-					// Populate email data.
-					$code_url = pmpro_url("checkout", "?level=" . $pmprogl_gift_levels[ intval( $data['membership_id'] ) ]['level_id'] . "&discount_code=" . $gift_code);
-					$data['pmprogl_gift_code'] = $gift_code;
-					$data['pmprogl_gift_code_url'] = $code_url;
-					$data['pmprogl_confirmation_message'] = pmprogl_get_confirmation_message( $data['membership_id'], $gift_code );
-				}
-			}
-		}
-	}
-
-	// Track whether an email template variable is being used so that we can avoid showing the default text.
-	if ( strpos( $pmpro_email->body, '!!pmprogl_' ) !== false ) {
-		global $pmprogl_email_template_var_used;
-		$pmprogl_email_template_var_used = true;
-	}
-	return $data;
-}
-add_filter( 'pmpro_email_data', 'pmprogl_checkout_email_data', 10, 2 );
-
-/**
- * If a PMPro Gift Level email template variable was not used, add the
- * PMPro Gift Levels confirmation message to the checkout email.
- *
- * @param string $body of email
- * @param PMProEmail $pmpro_email being sent.
- */
-function pmprogl_pmpro_email_body($body, $pmpro_email)
-{
-    global $wpdb, $pmprogl_gift_levels, $current_user, $pmprogl_email_template_var_used;
-
-    //only checkout emails, not admins
-    if(strpos($pmpro_email->template, "checkout") !== false && strpos($pmpro_email->template, "admin") == false && empty( $pmprogl_email_template_var_used ) )
-    {
-        //get the user_id from the email
-        $user_id = $wpdb->get_var("SELECT ID FROM $wpdb->users WHERE user_email = '" . $pmpro_email->data['user_email'] . "' LIMIT 1");
-        $level_id = $pmpro_email->data['membership_id'];
-
-        //get the user's last purchased gift code
-        $gift_codes = get_user_meta($current_user->ID, "pmprogl_gift_codes_purchased", true);
-
-        if(is_array($gift_codes))
-            $code_id = end($gift_codes);
-
-        if(!empty($code_id))
-        {
-            $code = $wpdb->get_var("SELECT code FROM $wpdb->pmpro_discount_codes WHERE id = '" . intval($code_id) . "' LIMIT 1");
-            if(!empty($code))
-                $body .= pmprogl_get_confirmation_message( $level_id, $code );
-        }
-    }
-	unset( $pmprogl_email_template_var_used );
-    return $body;
-}
-add_filter("pmpro_email_body", "pmprogl_pmpro_email_body", 10, 2);
-
-function pmprogl_send_gift_code_to_gift_recipient( $recipient_email, $gift_message, $gift_code ) {
-	global $pmprogl_gift_levels;
-
-	$email = new PMProEmail();
-	$email->email = $recipient_email;
-	$email->template = "pmprogl_gift_recipient";
-	$email->subject = esc_html__( "You have been gifted a membership to ", 'pmpro_gift_levels' ) . "!!sitename!!!";
-	$email->body = pmprogl_get_default_gift_recipient_email_body();
-	$email->pmprogl_gift_message = $gift_message; // Save this for later.
-	$email->pmprogl_gift_code = $gift_code; // Save this for later.
-
-	add_filter( 'option_pmpro_email_header_disabled', '__return_true', 15 );
-	add_filter( 'default_option_pmpro_email_header_disabled', '__return_true', 15 );
-	add_filter( 'option_pmpro_email_footer_disabled', '__return_true', 15 );
-	add_filter( 'default_option_pmpro_email_footer_disabled', '__return_true', 15 );
-	$email->sendEmail();
-	remove_filter( 'option_pmpro_email_header_disabled', '__return_true', 15 );
-	remove_filter( 'default_option_pmpro_email_header_disabled', '__return_true', 15 );
-	remove_filter( 'option_pmpro_email_footer_disabled', '__return_true', 15 );
-	remove_filter( 'default_option_pmpro_email_footer_disabled', '__return_true', 15 );
-}
-
-/**
- * Add "pmprogl_gift_recipient" as an editable email template.
+ * Add Gift Membership-specific templates to the email templates.
  *
  * @param array $templates that can be edited.
  */
 function pmprogl_template_callback( $templates ) {
 	$templates['pmprogl_gift_recipient'] = array(
-		'subject' => esc_html( sprintf( __( "You have been gifted a membership to %s", 'pmpro_gift_levels' ), get_option("blogname") ) ),
-		'description' => 'Gift Recipient',
+		'subject' => esc_html( sprintf( __( 'You have been gifted a membership to %s', 'pmpro_gift_levels' ), get_option( 'blogname' ) ) ),
+		'description' => __( 'Gift Recipient', 'pmpro-gift-levels' ),
 		'body' => pmprogl_get_default_gift_recipient_email_body(),
+		'help_text' => __( 'This email is sent when the gift giver provides the recipient email address at checkout. Additional placeholder variables you can use in this email template include !!pmprogl_giver_display_name!!, !!pmprogl_gift_message!!, !!pmprogl_gift_code!!, and !!pmprogl_gift_code_url!!.', 'pmpro-gift-levels' )
+	);
+	$templates['pmprogl_gift_purchased'] = array(
+		'subject' => esc_html( sprintf( __( 'Gift membership purchase confirmation for %s', 'pmpro_gift_levels' ), get_option( 'blogname' ) ) ),
+		'description' => __( 'Gift Purchased', 'pmpro-gift-levels' ),
+		'body' => pmprogl_get_default_gift_purchased_email_body(),
+		'help_text' => __( 'This email is sent to the gift giver as confirmation of their purchase after checkout. Additional placeholder variables you can use in this email template include !!pmprogl_giver_display_name!!, !!pmprogl_gift_message!!, !!pmprogl_gift_code!!, and !!pmprogl_gift_code_url!!.', 'pmpro-gift-levels' )
+	);
+	$templates['pmprogl_gift_purchased_admin'] = array(
+		'subject' => esc_html( sprintf( __( '!!pmprogl_giver_display_name!! has purchased a gift membership to %s', 'pmpro_gift_levels' ), get_option( 'blogname' ) ) ),
+		'description' => __( 'Gift Purchased (admin)', 'pmpro-gift-levels' ),
+		'body' => pmprogl_get_default_gift_purchased_admin_email_body(),
+		'help_text' => __( 'This email is sent to the admin as confirmation of gift purchase after checkout. Additional placeholder variables you can use in this email template include !!pmprogl_giver_display_name!!, !!pmprogl_gift_message!!, !!pmprogl_gift_code!!, and !!pmprogl_gift_code_url!!.', 'pmpro-gift-levels' )
 	);
 	
 	return $templates;
@@ -123,41 +29,53 @@ function pmprogl_template_callback( $templates ) {
 add_filter( 'pmproet_templates', 'pmprogl_template_callback');
 
 /**
- * Add PMPro Gift Code email template variables to the gift recipeient email.
+ * Default email content for the gift recipient email template.
  *
- * @param array $data current email template variables.
- * @param PMProEmail $pmpro_email being sent.
- * @return array
  */
-function pmprogl_gift_recipient_email_data( $data, $pmpro_email ) {
-	global $pmprogl_gift_levels, $pmpro_level, $current_user;
-	if ( $pmpro_email->template === 'pmprogl_gift_recipient' ) {
-		if ( empty( $pmpro_email->pmprogl_gift_code ) ) {
-			$pmpro_email->pmprogl_gift_code = '';
-		}
-		if ( empty( $pmpro_email->pmprogl_gift_message ) ) {
-			$empty_gift_message = '[' . esc_html__( 'No Message Provided', 'pmpro-gift-levels' ) . ']';
-			$pmpro_email->pmprogl_gift_message = apply_filters( 'pmprogl_empty_gift_message', $empty_gift_message, $pmpro_email );
-		}
-		$data['pmprogl_giver_display_name']   = $current_user->display_name;
-		$data['pmprogl_gift_message']  = $pmpro_email->pmprogl_gift_message;
-		$data['pmprogl_gift_code']     = $pmpro_email->pmprogl_gift_code;
-		$data['pmprogl_gift_code_url'] = pmpro_url("checkout", "?level=" . $pmprogl_gift_levels[ intval( $pmpro_level->id ) ]['level_id'] . "&discount_code=" . $pmpro_email->pmprogl_gift_code);
-	}
-	return $data;
-}
-add_filter( 'pmpro_email_data', 'pmprogl_gift_recipient_email_data', 10, 2 );
-
 function pmprogl_get_default_gift_recipient_email_body() {
-	ob_start();
-	?>
-<p><?php esc_html_e( '!!pmprogl_giver_display_name!! has just sent you a gift membership to !!sitename!!!', 'pmpro-gift_levels' ); ?></p>
+	ob_start(); ?>
+<p><?php esc_html_e( '!!pmprogl_giver_display_name!! has just sent you a gift membership to !!sitename!!!', 'pmpro-gift-levels' ); ?></p>
+!!pmprogl_gift_message!!
+<p><?php esc_html_e( 'Use this link to set up your membership:', 'pmpro-gift-levels' ); ?> <a href="!!pmprogl_gift_code_url!!">!!pmprogl_gift_code_url!!</a></p><?php
+	$body = ob_get_contents();
+	ob_end_clean();
+	return $body;
+}
 
-<p><?php esc_html_e( 'Message:', 'pmpro-gift_levels' ); ?></p>
-<p>!!pmprogl_gift_message!!</p>
-<hr>
-<p><?php esc_html_e( 'Use this link to setup your membership', 'pmpro-gift_levels' ); ?>: <a href="!!pmprogl_gift_code_url!!">!!pmprogl_gift_code_url!!</a></p>
-	<?php
+/**
+ * Default email content for the gift purchased email template sent to the user purchasing the gift.
+ *
+ */
+function pmprogl_get_default_gift_purchased_email_body() {
+	ob_start(); ?>
+<p><?php esc_html_e( 'Thank you for your purchase at !!sitename!!. Below is a receipt for your purchase.', 'pmpro-gift-levels' ); ?></p>
+<p><?php esc_html_e( 'Account: !!display_name!! (!!user_email!!)', 'pmpro-gift-levels' ); ?></p>
+<p>
+	<?php esc_html_e( 'Invoice #!!invoice_id!! on !!invoice_date!!', 'pmpro-gift-levels' ); ?><br />
+	<?php esc_html_e( 'Total Billed: !!invoice_total!!', 'pmpro-gift-levels' ); ?>
+</p>
+<p><strong><?php esc_html_e( 'Share this link with your gift recipient:', 'pmpro-gift-levels' ); ?> <a href="!!pmprogl_gift_code_url!!">!!pmprogl_gift_code_url!!</a></strong></p>
+<p><?php esc_html_e( 'Log in to view your purchase history here: !!login_url!!', 'pmpro-gift-levels' ); ?></p>
+<p><?php esc_html_e( 'To view an online version of this invoice, click here: !!invoice_url!!', 'pmpro-gift-levels' ); ?></p><?php
+	$body = ob_get_contents();
+	ob_end_clean();
+	return $body;
+}
+
+/**
+ * Default email content for the gift purchased email template sent to admin after a user purchases a gift.
+ *
+ */
+function pmprogl_get_default_gift_purchased_admin_email_body() {
+	ob_start(); ?>
+<p><?php esc_html_e( 'There was a new gift membership checkout at !!sitename!!.', 'pmpro-gift-levels' ); ?></p>
+<p><?php esc_html_e( 'Below are details about the purchase and a receipt for the initial invoice.', 'pmpro-gift-levels' ); ?></p>
+<p><?php esc_html_e( 'Account: !!display_name!! (!!user_email!!)', 'pmpro-gift-levels' ); ?></p>
+<p>
+	<?php esc_html_e( 'Invoice #!!invoice_id!! on !!invoice_date!!', 'pmpro-gift-levels' ); ?><br />
+	<?php esc_html_e( 'Total Billed: !!invoice_total!!', 'pmpro-gift-levels' ); ?><br />
+	<?php esc_html_e( 'Gift Code: !!pmprogl_gift_code!!', 'pmpro-gift-levels' ); ?>
+</p><?php
 	$body = ob_get_contents();
 	ob_end_clean();
 	return $body;

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -23,8 +23,8 @@ function pmprogl_invoice_bullets_bottom( $order ) {
 		if ( ! empty( $gift_code_id ) ) {
 			$code = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_discount_codes WHERE id = '" . intval( $gift_code_id ) . "' LIMIT 1" );
 			$code_level_id = $wpdb->get_var("SELECT level_id FROM $wpdb->pmpro_discount_codes_levels WHERE code_id = '" . intval($gift_code_id) . "' LIMIT 1");
-			$code_url = pmpro_url("checkout", "?level=" . $code_level_id . "&discount_code=" . $code->code);
-			if ( ! empty( $code ) ) { ?>
+			if ( ! empty( $code ) && ! empty( $code_level_id ) ) { ?>
+				$code_url = pmpro_url("checkout", "?level=" . $code_level_id . "&discount_code=" . $code->code);
 				<li><strong><?php esc_html_e( 'Gift Code:', 'pmpro-gift-levels'); ?></strong> <?php echo esc_html( $code->code ); ?></li>
 				<li>
 					<strong><?php esc_html_e( 'Gift Checkout URL:', 'pmpro-gift-levels' ); ?></strong> <?php echo esc_html( $code_url ); ?></li>

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -22,17 +22,20 @@ function pmprogl_invoice_bullets_bottom( $order ) {
 		
 		if ( ! empty( $gift_code_id ) ) {
 			$code = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_discount_codes WHERE id = '" . intval( $gift_code_id ) . "' LIMIT 1" );
-			if ( ! empty( $code ) ) {
-				?><li><strong><?php _e('Gift Code', 'pmprogl');?>: </strong><?php echo $code->code;?></li><?php
-			}			
+			$code_level_id = $wpdb->get_var("SELECT level_id FROM $wpdb->pmpro_discount_codes_levels WHERE code_id = '" . intval($gift_code_id) . "' LIMIT 1");
+			$code_url = pmpro_url("checkout", "?level=" . $code_level_id . "&discount_code=" . $code->code);
+			if ( ! empty( $code ) ) { ?>
+				<li><strong><?php esc_html_e( 'Gift Code:', 'pmpro-gift-levels'); ?></strong> <?php echo esc_html( $code->code ); ?></li>
+				<li>
+					<strong><?php esc_html_e( 'Gift Checkout URL:', 'pmpro-gift-levels' ); ?></strong> <?php echo esc_html( $code_url ); ?></li>
+			<?php }
 		}
 	}
 }
 add_filter( 'pmpro_invoice_bullets_bottom', 'pmprogl_invoice_bullets_bottom' );
 
 /**
- * Show all gift codes that the current user has purchased on the PMPro
- * Account page.
+ * Show all gift codes that the current user has purchased on the Membership Account page.
  *
  * @param string $content of `[pmpro_account]` shortcode
  * @return string
@@ -48,7 +51,7 @@ function pmprogl_the_content_account_page($content)
 		
 		if(!empty($gift_codes))
 		{
-			$temp_content = pmprogl_build_gift_code_table();
+			$temp_content = pmprogl_build_gift_code_list();
 			$content = str_replace('<!-- end pmpro_account-profile -->', '<!-- end pmpro_account-profile -->' . $temp_content, $content);
  		}
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -86,12 +86,12 @@ function pmprogl_get_confirmation_message( $level_id, $gift_code ) {
 }
 
 /**
- * Build a table showing all gift codes purchased by the current user.
+ * Build a unordered list showing all gift codes and claim status purchased by the current user.
  *
- * @param int|null $user_id to build table for.
+ * @param int|null $user_id to build list for.
  * @return string
  */
-function pmprogl_build_gift_code_table( $user_id = null ){
+function pmprogl_build_gift_code_list( $user_id = null ){
 	global $current_user, $wpdb;
 
 	if ( empty( $user_id ) ) {
@@ -121,13 +121,11 @@ function pmprogl_build_gift_code_table( $user_id = null ){
 					?>
 					<li>
 						<?php 
-						if(!empty($code_use)) 
-						{ 
-							echo $code->code, " ", esc_html__("claimed by", "pmpro-gift-levels" ), " ";
+						 if ( ! empty( $code_use ) ) {
 							$code_user = get_userdata( $code_use ); 
-							echo esc_html( $code_user->display_name );
+							printf( __( '%s: claimed by %s', 'pmpro-gift-levels' ), esc_html( $code->code ), esc_html( $code_user->display_name ) );
 						} else { ?>
-							<a target="_blank" href="<?php echo esc_attr( $code_url );?>"><?php echo esc_html( $code->code );?></a>
+							<a target="_blank" href="<?php echo esc_attr( $code_url );?>"><?php echo esc_html( $code->code ); ?></a>
 						<?php } ?>
 					</li>
 					<?php

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -46,46 +46,6 @@ function pmprogl_populate_gift_levels_array() {
 add_action( 'init', 'pmprogl_populate_gift_levels_array', 15 );
 
 /**
- * Build a PMPro Gift Levels confirmation message.
- *
- * @param int $level_id that was used to purchase $gift_code.
- * @param string $gift_code to get confirmation message for.
- * @return string
- */
-function pmprogl_get_confirmation_message( $level_id, $gift_code ) {
-	global $wpdb, $pmprogl_gift_levels;
-
-	// Check that this is a gift membership level...
-	if ( empty( $pmprogl_gift_levels[ intval( $level_id ) ] ) ) {
-		return '';
-	}
-
-	// Get the gift membership level...
-	$gift_membership_level = $pmprogl_gift_levels[ intval( $level_id ) ]['level_id'];
-	if ( empty( $gift_membership_level ) ) {
-		// $level_id is not a gift level. Return.
-		return '';
-	}
-
-	// Get the raw confirmation message...
-	$confirmation_message = get_pmpro_membership_level_meta( $level_id, 'pmprogl_confirmation_message', true );
-	if ( empty( $confirmation_message ) ) {
-		$confirmation_message = '<p><strong>' . __( 'Share this link with your gift recipient' ) . ': <a href="!!pmprogl_gift_code_url!!">!!pmprogl_gift_code_url!!</a></p></strong>';
-	}
-
-	// Replace the variables...
-	$variables = array(
-		'pmprogl_gift_code' => $gift_code,
-		'pmprogl_gift_code_url' => pmpro_url( 'checkout', '?level=' . $gift_membership_level . '&discount_code=' . $gift_code ),
-	);
-	foreach($variables as $key => $value) {
-		$confirmation_message = str_replace( '!!' . $key . '!!', $value, $confirmation_message );
-	}
-
-	return $confirmation_message;
-}
-
-/**
  * Build a unordered list showing all gift codes and claim status purchased by the current user.
  *
  * @param int|null $user_id to build list for.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Fixed undefined index warning for pmprogl_gift_level
- Adjusted css selectors and wording for the gift recipient email option at checkout
- Changed table to list in function and doc blocks; now showing code claim URL on invoice page as well as the code itself.
- Removing the confirmation message field per level. This can be adjusted for all gift levels by editing the Gift Purchased email on Memberships > Settings > Email Templates admin page.
- Removed an unused function to get the confirmation message.
- Added email templates for gift purchaser, admin when a gift is purchased, and gift recipient. This will send these emails at checkout instead of default checkout emails to user and admin (which assume a membership level is assigned to the purchaser).