### PR TITLE
Level template and new section for level add/edit page for PMPro v2.9+

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,4 +1,22 @@
 <?php
+/**
+ * Add the gift membership level template
+ */
+function pmprogl_membershiplevels_template_level( $level, $template ) {
+	if ( $template === 'gift' ) {
+		$level->billing_amount = NULL;
+		$level->trial_amount = NULL;
+		$level->initial_payment = '25';
+		$level->billing_limit = NULL;
+		$level->trial_limit = NULL;
+		$level->expiration_number = NULL;
+		$level->expiration_period = NULL;
+		$level->cycle_number = 1;
+		$level->cycle_period = 'Month';
+	}
+	return $level;
+}
+add_filter( 'pmpro_membershiplevels_template_level', 'pmprogl_membershiplevels_template_level', 10, 2 );
 
 /**
  * Add PMPro Gift Levels settings to the "Edit Level" page.
@@ -9,100 +27,141 @@ function pmprogl_membership_level_after_other_settings() {
 	global $wpdb, $wp_version;
 	$edit_level_id        = $_REQUEST['edit'];
 
-	$enabled              = 'yes' === get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_enabled_for_level', true );
-	$gift_level_checked   = $enabled ? ' checked' : '';
-
-	$gift_level           = intval( get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_gift_level', true ) );
-
-	$allow_gift_emails = get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_allow_gift_emails', true );
-	if ( empty( $allow_gift_emails ) ) {
-		$allow_gift_emails = 'no';
+	// Get the template if passed in the URL.
+	if ( isset( $_REQUEST['template'] ) ) {
+		$template = $_REQUEST['template'];
+	} else {
+		$template = false;
 	}
 
-	$expiration_number = intval( get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_expiration_number', true ) );
-	$expiration_period = get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_expiration_period', true );
-	if ( empty( $expiration_period ) ) {
-		$expiration_period = 'Day';
-	}
+	// Set template default if this is a new gift level.
+	if ( $template === 'gift' && $edit_level_id === '-1' ) {
+		$enabled = 'yes';
+		$gift_level_checked = ' checked';
+		$gift_level = 0;
+		$allow_gift_emails = 'yes';
+		$expiration_number = 3;
+		$expiration_period = 'Month';
+	} else {
+		$enabled          = 'yes' === get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_enabled_for_level', true );
 
-	?>
-	<hr>
-	<h2 class="title"><?php esc_html_e( 'Gift Membership', 'pmpro-gift-levels' ); ?></h2>
-	<p><?php esc_html_e( 'This level can be assigned as a "gift level" that users can purchase. After checkout, the gift giver will receive a code they can share with the recipient. To enable this feature, choose a level from the dropdown below. The selected level is the level that will be given to the user who claims the gift code generated after purchase.', 'pmpro-gift-levels' ); ?> <a href="https://www.paidmembershipspro.com/add-ons/pmpro-gift-levels/?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=add-ons&utm_content=pmpro-gift-levels" target="_blank"><?php esc_html_e( 'Click here to read the Gift Membership Add On documentation.', 'pmpro-gift-levels' ); ?></a></p>
-	<?php
-		// Populate an array of all membership levels, then remove the currently edited level from the array.
-		$giftable_levels = pmpro_sort_levels_by_order( pmpro_getAllLevels(false, true) );
-		if ( ! empty( strval( $edit_level_id ) ) && ! empty( $giftable_levels[ strval( $edit_level_id ) ] ) ) {
-			$current_level = $giftable_levels[ strval( $edit_level_id ) ];
-			unset( $giftable_levels[ strval( $edit_level_id ) ] );
+		$gift_level_checked   = $enabled ? ' checked' : '';
+
+		$gift_level           = intval( get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_gift_level', true ) );
+
+		$allow_gift_emails = get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_allow_gift_emails', true );
+		if ( empty( $allow_gift_emails ) ) {
+			$allow_gift_emails = 'no';
 		}
 
-		// Show an error if currently edited level has a recurring subscription or membership expiration set.
-		if ( ! empty( $current_level ) && ( ! empty( intval( $current_level->billing_amount ) ) || ! empty( intval( $current_level->expiration_number ) ) ) ) {
-			?>
-			<div class="pmprogl_gift_level_toggle_setting notice error" <?php if( empty( $gift_level ) ) {?>style="display: none;"<?php } ?>>
-				<p><strong><?php esc_html_e( 'Gift Membership Warning:', 'pmpro-gift-levels' ); ?></strong> <?php esc_html_e( 'The settings of this level are not recommended. Remove the recurring subscription and membership expiration from this level.', 'pmpro-gift-levels' ); ?></p>
-			</div>
+		$expiration_number = intval( get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_expiration_number', true ) );
+		$expiration_period = get_pmpro_membership_level_meta( $edit_level_id, 'pmprogl_expiration_period', true );
+		if ( empty( $expiration_period ) ) {
+			$expiration_period = 'Day';
+		}
+	}
+
+	// Hide or show this section based on settings
+	if ( $template === 'gift' || $enabled == 'yes' ) {
+		$section_visibility = 'shown';
+		$section_activated = 'true';
+	} else {
+		$section_visibility = 'hidden';
+		$section_activated = 'false';
+	}
+	?>
+	<div id="gift-settings" class="pmpro_section" data-visibility="<?php echo esc_attr( $section_visibility ); ?>" data-activated="<?php echo esc_attr( $section_activated ); ?>">
+		<div class="pmpro_section_toggle">
+			<button class="pmpro_section-toggle-button" type="button" aria-expanded="<?php echo $section_visibility === 'hidden' ? 'false' : 'true'; ?>">
+				<span class="dashicons dashicons-arrow-<?php echo $section_visibility === 'hidden' ? 'down' : 'up'; ?>-alt2"></span>
+				<?php esc_html_e( 'Gift Membership', 'pmpro-gift-levels' ); ?>
+			</button>
+		</div>
+		<div class="pmpro_section_inside" <?php echo $section_visibility === 'hidden' ? 'style="display: none"' : ''; ?>>
+			<p><?php esc_html_e( 'This level can be assigned as a "gift level" that users can purchase. After checkout, the gift giver will receive a code they can share with the recipient. To enable this feature, choose a level from the dropdown below. The selected level is the level that will be given to the user who claims the gift code generated after purchase.', 'pmpro-gift-levels' ); ?> <a rel="nofollow noopener" href="https://www.paidmembershipspro.com/add-ons/pmpro-gift-levels/?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=add-ons&utm_content=pmpro-gift-levels" target="_blank"><?php esc_html_e( 'Click here to read the Gift Membership Add On documentation.', 'pmpro-gift-levels' ); ?></a></p>
 			<?php
-		}
-	?>
-	<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top"><label><?php esc_html_e('Gift Level?', 'pmpro-gift-levels' );?>:</label></th>
-				<td>
-					<input type="checkbox" id="pmprogl_enabled_for_level" name="pmprogl_enabled_for_level" value="1" <?php echo $gift_level_checked; ?> />
-				</td>
-			</tr>
-			<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php }  ?>>
-				<th scope="row" valign="top"><label><?php esc_html_e('Level to Gift', 'pmpro-gift-levels' );?>:</label></th>
-				<td>
-					<select id="pmprogl_gift_level" name="pmprogl_gift_level">
-						<?php
-						// Show a dropdown of all membership levels, excluding the currently edited level.
-						foreach ( $giftable_levels as $level_id => $level ) {
-							echo "<option value='" . esc_attr( $level_id ) . "' " . selected( $gift_level, intval ( $level_id ), false ) . ">" . esc_html( $level->name ) . "</option>";
-						}
-						?>
-					</select>
-				</td>
-			</tr>
-			<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php } ?>>
-				<th scope="row" valign="top"><?php esc_html_e('Allow Gift Emails', 'pmpro-gift-levels' ); ?>:</th>
- 				<td>
- 					<input id="pmprogl_allow_gift_emails" name="pmprogl_allow_gift_emails" type="checkbox" value="yes" <?php if( 'yes' === $allow_gift_emails ) { ?>checked="checked"<?php } ?> />
-					<label for="pmprogl_allow_gift_emails"><?php esc_html_e( 'Check to allow customers to enter the recipient email address at checkout.', 'pmpro-gift-levels' );?></label>
-					<p class="description"><?php esc_html_e( 'If an email address is provided, the recipient will automatically receive an email containing a personalized message and a link to claim the gift code. You can customize the "Gift Recipient" template on the Memberships > Settings > Email Templates page in the WordPress admin.', 'pmpro-gift-levels' ); ?></p>
- 				</td>
- 			</tr>
-			<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php } ?>>
-				<th scope="row" valign="top"><?php esc_html_e('Gift Membership Expires', 'pmpro-gift-levels' ); ?>:</th>
-				<td>
-					<input id="pmprogl_gift_expires" name="pmprogl_gift_expires" type="checkbox" value="yes" <?php if ( $expiration_number ) { echo "checked='checked'"; } ?>/>
-					<label for="pmprogl_gift_expires"><?php esc_html_e( 'Check this to set an expiration period for the gifted membership level.', 'pmpro_gift_levels' ); ?></label>
-					<p class="description"><?php esc_html_e( 'If you do not set an expiration period, the gift recipient\'s membership will never expire.', 'pmpro-gift-levels' ); ?></p>
-				</td>
-			</tr>
-			<tr id="pmprogl_period_tr" <?php if( ! $enabled || empty( $expiration_number ) ) {?>style="display: none;"<?php } ?>>
-				<th scope="row" valign="top"><label><?php esc_html_e( 'Gift Expiration Period', 'pmpro-gift-levels' );?>:</label></th>
-				<td>
-					<input id="pmprogl_expiration_number" name="pmprogl_expiration_number" type="number" value="<?php echo esc_attr( $expiration_number );?>" />
-					<select id="pmprogl_expiration_period" name="pmprogl_expiration_period">
-						<?php
-						$cycles = array(  esc_html__('Day(s)', 'pmpro-gift-levels' ) => 'Day', esc_html__('Week(s)', 'pmpro-gift-levels' ) => 'Week', esc_html__('Month(s)', 'pmpro-gift-levels' ) => 'Month', esc_html__('Year(s)', 'pmpro-gift-levels' ) => 'Year' );													
-						foreach ( $cycles as $name => $value ) {
-							echo "<option value='$value' ".selected( $expiration_period, $value, true ).">$name</option>";
-						}
-						?>
-					</select>
-					<p class="description"><?php _e('Set the duration of membership access once the gift membership is redeemed.', 'pmpro-gift-levels' );?></p>
-				</td>
-			</tr>
-		</tbody>
-	</table>
+				// Populate an array of all membership levels, then remove the currently edited level from the array.
+				$giftable_levels = pmpro_sort_levels_by_order( pmpro_getAllLevels(false, true) );
+				if ( ! empty( strval( $edit_level_id ) ) && ! empty( $giftable_levels[ strval( $edit_level_id ) ] ) ) {
+					$current_level = $giftable_levels[ strval( $edit_level_id ) ];
+					unset( $giftable_levels[ strval( $edit_level_id ) ] );
+				}
+
+				// Show an error if currently edited level has a recurring subscription or membership expiration set.
+				if ( ! empty( $current_level ) && ( ! empty( intval( $current_level->billing_amount ) ) || ! empty( intval( $current_level->expiration_number ) ) ) ) {
+					?>
+					<div class="pmprogl_gift_level_toggle_setting notice error" <?php if( empty( $gift_level ) ) {?>style="display: none;"<?php } ?>>
+						<p><strong><?php esc_html_e( 'Gift Membership Warning:', 'pmpro-gift-levels' ); ?></strong> <?php esc_html_e( 'The settings of this level are not recommended. Remove the recurring subscription and membership expiration from this level.', 'pmpro-gift-levels' ); ?></p>
+					</div>
+					<?php
+				}
+			?>
+			<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Gift Level?', 'pmpro-gift-levels' ); ?></label></th>
+						<td>
+							<input type="checkbox" id="pmprogl_enabled_for_level" name="pmprogl_enabled_for_level" value="1" <?php echo $gift_level_checked; ?> />
+						</td>
+					</tr>
+					<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php }  ?>>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Level to Gift', 'pmpro-gift-levels' );?></label></th>
+						<td>
+							<select id="pmprogl_gift_level" name="pmprogl_gift_level">
+								<?php
+								// Show a dropdown of all membership levels, excluding the currently edited level.
+								foreach ( $giftable_levels as $level_id => $level ) {
+									echo "<option value='" . esc_attr( $level_id ) . "' " . selected( $gift_level, intval ( $level_id ), false ) . ">" . esc_html( $level->name ) . "</option>";
+								}
+								?>
+							</select>
+						</td>
+					</tr>
+					<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php } ?>>
+						<th scope="row" valign="top"><?php esc_html_e( 'Allow Gift Emails', 'pmpro-gift-levels' ); ?></th>
+		 				<td>
+		 					<input id="pmprogl_allow_gift_emails" name="pmprogl_allow_gift_emails" type="checkbox" value="yes" <?php if( 'yes' === $allow_gift_emails ) { ?>checked="checked"<?php } ?> />
+							<label for="pmprogl_allow_gift_emails"><?php esc_html_e( 'Check to allow customers to enter the recipient email address at checkout.', 'pmpro-gift-levels' );?></label>
+							<p class="description"><?php esc_html_e( 'If an email address is provided, the recipient will automatically receive an email containing a personalized message and a link to claim the gift code. You can customize the "Gift Recipient" template on the Memberships > Settings > Email Templates page in the WordPress admin.', 'pmpro-gift-levels' ); ?></p>
+		 				</td>
+		 			</tr>
+					<tr class="pmprogl_gift_level_toggle_setting" <?php if( ! $enabled ) {?>style="display: none;"<?php } ?>>
+						<th scope="row" valign="top"><?php esc_html_e( 'Gift Membership Expires', 'pmpro-gift-levels' ); ?></th>
+						<td>
+							<input id="pmprogl_gift_expires" name="pmprogl_gift_expires" type="checkbox" value="yes" <?php if ( $expiration_number ) { echo "checked='checked'"; } ?>/>
+							<label for="pmprogl_gift_expires"><?php esc_html_e( 'Check this to set an expiration period for the gifted membership level.', 'pmpro_gift_levels' ); ?></label>
+							<p class="description"><?php esc_html_e( 'If you do not set an expiration period, the gift recipient\'s membership will never expire.', 'pmpro-gift-levels' ); ?></p>
+						</td>
+					</tr>
+					<tr id="pmprogl_period_tr" <?php if( ! $enabled || empty( $expiration_number ) ) {?>style="display: none;"<?php } ?>>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Gift Expiration Period', 'pmpro-gift-levels' ); ?></label></th>
+						<td>
+							<input id="pmprogl_expiration_number" name="pmprogl_expiration_number" type="number" value="<?php echo esc_attr( $expiration_number );?>" />
+							<select id="pmprogl_expiration_period" name="pmprogl_expiration_period">
+								<?php
+								$cycles = array(  esc_html__('Day(s)', 'pmpro-gift-levels' ) => 'Day', esc_html__('Week(s)', 'pmpro-gift-levels' ) => 'Week', esc_html__('Month(s)', 'pmpro-gift-levels' ) => 'Month', esc_html__('Year(s)', 'pmpro-gift-levels' ) => 'Year' );													
+								foreach ( $cycles as $name => $value ) {
+									echo "<option value='$value' ".selected( $expiration_period, $value, true ).">$name</option>";
+								}
+								?>
+							</select>
+							<p class="description"><?php _e('Set the duration of membership access once the gift membership is redeemed.', 'pmpro-gift-levels' );?></p>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div> <!-- end pmpro_section_inside -->
+	</div> <!-- end pmpro_section -->
 	<?php
 }
-add_action( 'pmpro_membership_level_after_other_settings', 'pmprogl_membership_level_after_other_settings' );
+/**
+ * Load settings section using new hook on Edit Level screen.
+ */
+if ( defined( 'PMPRO_VERSION' ) && PMPRO_VERSION >= '2.9' ) {
+	add_action( 'pmpro_membership_level_before_content_settings', 'pmprogl_membership_level_after_other_settings' );
+} else {
+	add_action( 'pmpro_membership_level_after_other_settings', 'pmprogl_membership_level_after_other_settings' );
+}
 
 function pmprogl_save_membership_level( $save_id ) {
 	global $allowedposttags;

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Add the gift membership level template
+ * @since 1.0.2
  */
 function pmprogl_membershiplevels_template_level( $level, $template ) {
 	if ( $template === 'gift' ) {
@@ -29,7 +30,7 @@ function pmprogl_membership_level_after_other_settings() {
 
 	// Get the template if passed in the URL.
 	if ( isset( $_REQUEST['template'] ) ) {
-		$template = $_REQUEST['template'];
+		$template = sanitize_text_field( $_REQUEST['template'] );
 	} else {
 		$template = false;
 	}
@@ -145,7 +146,7 @@ function pmprogl_membership_level_after_other_settings() {
 								}
 								?>
 							</select>
-							<p class="description"><?php _e('Set the duration of membership access once the gift membership is redeemed.', 'pmpro-gift-levels' );?></p>
+							<p class="description"><?php esc_html_e('Set the duration of membership access once the gift membership is redeemed.', 'pmpro-gift-levels' );?></p>
 						</td>
 					</tr>
 				</tbody>

--- a/pmpro-gift-levels.php
+++ b/pmpro-gift-levels.php
@@ -3,14 +3,14 @@
 Plugin Name: Paid Memberships Pro - Gift Levels Add On
 Plugin URI: http://www.paidmembershipspro.com/add-ons/pmpro-gift-levels/
 Description: Some levels will generate discount codes to give to others to use for gift memberships.
-Version: 1.0.1
+Version: 1.0.2
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 Text Domain: pmpro-gift-levels
 Domain Path: /languages
 */
 
-define( 'PMPROGL_VERSION', '0.4' );
+define( 'PMPROGL_VERSION', '1.0.2' );
 define( 'PMPROGL_BASE_FILE', __FILE__ );
 define( 'PMPROGL_DIR', dirname( __FILE__ ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: strangerstudios
 Tags: pmpro, paid memberships pro, membership, gift, gift level, gift card, giftcard, gift certificate
 Requires at least: 4.5
-Tested up to: 5.8
-Stable tag: 1.0.1
+Tested up to: 6.0
+Stable tag: 1.0.2
 
 == Description ==
 
@@ -32,6 +32,9 @@ Refer to the [Gift Levels Add On documentation page](https://www.paidmemberships
 Please post it in the issues section of GitHub and we'll fix it as soon as we can. Thanks for helping. https://github.com/strangerstudios/pmpro-gift-levels/issues
 
 == Changelog ==
+= 1.0.2 - 2022-07-19 =
+* ENHANCEMENT: Added Gift level template and support for PMPro v2.9+ settings UI.
+
 = 1.0.1 - 2021-09-14 =
 * BUG FIX: Fixed fatal error when viewing Edit User page
 * BUG FIX: Fixed incorrect output on invoice page when a gift order was purchased


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The redesign of the Membership Levels page + templates are slated for PMPro v2.9. We are including Gift in the template list. This PR updates the Gift Membership section to match the v2.9+ format for the levels admin page.

<img width="967" alt="Screen Shot 2022-05-31 at 9 59 02 AM" src="https://user-images.githubusercontent.com/5312875/171191880-8822229a-fcf5-46ce-b473-922cbb0cdd55.png">

v2.9 adds new hooks so that Add Ons like this can place their settings in more places on the edit page. I have conditionally used the new hook to show this box right below the expiration settings of that new UI.

<img width="1122" alt="Screen Shot 2022-05-31 at 9 58 47 AM" src="https://user-images.githubusercontent.com/5312875/171191970-2c6cb057-ae2c-40b5-a7c7-c775e8b674dc.png">

For sites that are not on 2.9, the settings section will be shown as it is today at the bottom of the page.

Note that the appearance is a bit less than perfect since the new format relies on CSS in core PMPro v2.9+. I think rather than replicate this formatting or code to variations of the section we add based on PMPro version we just live with this less than desirable look and believe that people will upgrade core.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out the pending PR for the 'edit-levels-templates-cycle' from my GitHub user.
2. Go to Settings > Levels. Click Add New.
3. You'll see the "Gift" template. Click that.
4. On the Edit page, see the "Gift Membership" section right below the "Expiration Settings" section.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Added Gift level template and support for PMPro v2.9+ settings UI.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.