### PR TITLE
Fix for gift level check to be actually enabled first before we show the warning

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -89,7 +89,7 @@ function pmprogl_membership_level_after_other_settings() {
 				}
 
 				// Show an error if currently edited level has a recurring subscription or membership expiration set.
-				if ( ! empty( $current_level ) && ( ! empty( intval( $current_level->billing_amount ) ) || ! empty( intval( $current_level->expiration_number ) ) ) ) {
+				if ( ! empty( $current_level ) && ! empty( $enabled ) && ( ! empty( intval( $current_level->billing_amount ) ) || ! empty( intval( $current_level->expiration_number ) ) ) ) {
 					?>
 					<div class="pmprogl_gift_level_toggle_setting notice error" <?php if( empty( $gift_level ) ) {?>style="display: none;"<?php } ?>>
 						<p><strong><?php esc_html_e( 'Gift Membership Warning:', 'pmpro-gift-levels' ); ?></strong> <?php esc_html_e( 'The settings of this level are not recommended. Remove the recurring subscription and membership expiration from this level.', 'pmpro-gift-levels' ); ?></p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The warning was showing for all recurring levels - but this update fixes so it requires them to be "enabled" as a gift level before the recurring payment warning/notice shows.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #59.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX: Resolved issue where the recurring payment warning was showing on all levels, not just gift levels.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
