### PR TITLE
fixing some email vars and async checkout issues

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -49,7 +49,7 @@ function pmprogl_get_default_gift_recipient_email_body() {
 function pmprogl_get_default_gift_purchased_email_body() {
 	ob_start(); ?>
 <p><?php esc_html_e( 'Thank you for your purchase at !!sitename!!. Below is a receipt for your purchase.', 'pmpro-gift-levels' ); ?></p>
-<p><?php esc_html_e( 'Account: !!display_name!! (!!user_email!!)', 'pmpro-gift-levels' ); ?></p>
+<p><?php esc_html_e( 'Account: !!pmprogl_giver_display_name!! (!!pmprogl_giver_email!!)', 'pmpro-gift-levels' ); ?></p>
 <p>
 	<?php esc_html_e( 'Invoice #!!invoice_id!! on !!invoice_date!!', 'pmpro-gift-levels' ); ?><br />
 	<?php esc_html_e( 'Total Billed: !!invoice_total!!', 'pmpro-gift-levels' ); ?>
@@ -70,7 +70,7 @@ function pmprogl_get_default_gift_purchased_admin_email_body() {
 	ob_start(); ?>
 <p><?php esc_html_e( 'There was a new gift membership checkout at !!sitename!!.', 'pmpro-gift-levels' ); ?></p>
 <p><?php esc_html_e( 'Below are details about the purchase and a receipt for the initial invoice.', 'pmpro-gift-levels' ); ?></p>
-<p><?php esc_html_e( 'Account: !!display_name!! (!!user_email!!)', 'pmpro-gift-levels' ); ?></p>
+<p><?php esc_html_e( 'Account: !!pmprogl_giver_display_name!! (!!pmprogl_giver_email!!)', 'pmpro-gift-levels' ); ?></p>
 <p>
 	<?php esc_html_e( 'Invoice #!!invoice_id!! on !!invoice_date!!', 'pmpro-gift-levels' ); ?><br />
 	<?php esc_html_e( 'Total Billed: !!invoice_total!!', 'pmpro-gift-levels' ); ?><br />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Fixes issue where gift purchasers may not receive a confirmation email when using Stripe Checkout
- Fixes issue where gift emails sent to administrator may have their account details in place of the gift purchaser.
