### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -153,8 +153,9 @@ function pmprogl_pmpro_checkout_before_change_membership_level( $user_id = false
 	global $pmprogl_gift_levels;
 
 	// Get the level that the user is checking out for.
-	if ( ! empty( $_REQUEST['level'] ) ) {
-		$level_id = intval( $_REQUEST['level'] );
+	$checkout_level = pmpro_getLevelAtCheckout();
+	if ( ! empty( $checkout_level->id ) ) {
+		$level_id = intval( $checkout_level->id );
 	} elseif( ! empty( $morder->membership_id ) ) {
 		$level_id = intval( $morder->membership_id );
 	} else {


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.