### PR TITLE
Update headings hierarchy to match new PMPro checkout page for a11y

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -269,7 +269,7 @@ function pmprogl_discount_code_after_settings( $discount_code_id ) {
 
 	$user = get_userdata( $order->user_id );
 	if ( ! empty( $user ) ) {
-		echo '<strong>' . esc_html__( 'This discount code was purchased as a gift by', 'pmpro-gift-levels' ) . ' ' . '<a href="user-edit.php?user_id=' . $user->ID . '">' . $user->display_name . '</a></h3>';
+		echo '<strong>' . esc_html__( 'This discount code was purchased as a gift by', 'pmpro-gift-levels' ) . ' ' . '<a href="user-edit.php?user_id=' . $user->ID . '">' . $user->display_name . '</a></h2>';
 	}
 }
 add_action( 'pmpro_discount_code_after_settings', 'pmprogl_discount_code_after_settings' );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -269,7 +269,7 @@ function pmprogl_discount_code_after_settings( $discount_code_id ) {
 
 	$user = get_userdata( $order->user_id );
 	if ( ! empty( $user ) ) {
-		echo '<strong>' . esc_html__( 'This discount code was purchased as a gift by', 'pmpro-gift-levels' ) . ' ' . '<a href="user-edit.php?user_id=' . $user->ID . '">' . $user->display_name . '</a></h2>';
+		echo '<strong>' . esc_html__( 'This discount code was purchased as a gift by', 'pmpro-gift-levels' ) . ' ' . '<a href="user-edit.php?user_id=' . $user->ID . '">' . $user->display_name . '</a></strong>';
 	}
 }
 add_action( 'pmpro_discount_code_after_settings', 'pmprogl_discount_code_after_settings' );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -21,9 +21,9 @@ function pmprogl_checkout_boxes() {
 	?>
 	<div id="pmprogl_checkout_box" class="pmpro_checkout">
 		<hr />
-		<h3>
-			<span class="pmpro_checkout-h3-name"><?php esc_html_e( 'Gift Code', 'pmpro-gift-levels' );?></span>
-		</h3>
+		<h2>
+			<span class="pmpro_checkout-h2-name"><?php esc_html_e( 'Gift Code', 'pmpro-gift-levels' );?></span>
+		</h2>
 		<div class="pmpro_checkout-fields">
 			<div class="pmpro_checkout-field pmpro_checkout-field-checkbox">
 				<input type="checkbox" id="pmprogl_send_recipient_email" name="pmprogl_send_recipient_email" value="1" <?php echo $send_recipient_email_checked; ?> />

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -67,7 +67,7 @@ function pmprogl_build_gift_code_list( $user_id = null ){
 	?>
 	<div id="pmpro_account-gift_codes" class="pmpro_box">	
 
-		<h3><?php esc_html_e( "Gift Codes", "pmpro-gift-levels" ); ?></h3>
+		<h2><?php esc_html_e( "Gift Codes", "pmpro-gift-levels" ); ?></h2>
 		<ul>
 		<?php
 			foreach($gift_codes as $gift_code_id)


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.