### PR TITLE
Fix references to pmpro, when pmpro is not active

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -47,6 +47,11 @@ add_action( 'pmpro_checkout_boxes', 'pmprogl_checkout_boxes' );
  * Enqueue frontend JavaScript and CSS
  */
 function pmprogl_enqueue_checkout_script() {
+	if ( ! function_exists( 'pmpro_is_checkout' ) ) {
+		// PMPro is not active.
+        return;
+    }
+
 	// Checkout page JS
 	if ( pmpro_is_checkout() ) {
 		wp_enqueue_script( 'pmprogl_checkout', plugins_url( 'js/pmprogl-checkout.js', PMPROGL_BASE_FILE ), array( 'jquery' ), PMPROGL_VERSION  );

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -46,7 +46,7 @@ function pmprogl_the_content_account_page($content)
 {
 	global $post, $pmpro_pages, $current_user, $wpdb, $pmprogl_gift_levels;
 			
-	if(!is_admin() && isset( $post ) && $post->ID == $pmpro_pages['account'])
+	if(!is_admin() && isset( $post ) && isset( $pmpro_pages['account'] ) && $post->ID == $pmpro_pages['account'])
 	{
 		//get the user's last purchased gift code
 		$gift_codes = get_user_meta($current_user->ID, "pmprogl_gift_codes_purchased", true);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-gift-levels/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-gift-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves some fatals/warnings when PMPro is not active.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

